### PR TITLE
Changed composer package name to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are using Laravel its pretty easy to use the library:
 
 require in your composer file
 
-    "gufran/laravel-authorize-net-cim": "0.1.1"
+    "gufran/authorize-net-cim-api": "0.1.1"
 
 Add:
     


### PR DESCRIPTION
Looks like the readme package name didn't match the composer package name.
This was causing composer to throw an error:
- The requested package gufran/laravel-authorize-net-cim could not be found in any version, there may be a typo in the package name.
